### PR TITLE
Made meme preview image a link to the meme URL.

### DIFF
--- a/UpboatMe/Views/Shared/BuilderPartial.cshtml
+++ b/UpboatMe/Views/Shared/BuilderPartial.cshtml
@@ -1,6 +1,7 @@
 ﻿@model BuilderViewModel
 @{
     var previewUrl = Model.GetPreviewUrl(Url);
+    var isMemeReady = Model.Lines != null && Model.Lines.Any(l => !string.IsNullOrEmpty(l));
 }
 <div class="row">
     <div class="large-6 columns">
@@ -23,7 +24,7 @@
                 <input class="small button" type="submit" value="Create!" id="create-meme" />
             </div>
         </form>
-        @if (Model.Lines != null && Model.Lines.Any(l => !string.IsNullOrEmpty(l)))
+        @if (isMemeReady)
         {
             <div>
                 <h3 id="share">Share it!</h3>
@@ -53,6 +54,15 @@
         }
     </div>
     <div class="large-6 columns">
-        <img id="meme-preview" src="@(previewUrl)" alt="@(@Model.GetAltText())" title="@(@Model.GetAltText())"/>
+        @if (isMemeReady)
+        {
+            <a href="@previewUrl">
+                <img id="meme-preview" src="@(previewUrl)" alt="@(@Model.GetAltText())" title="@(@Model.GetAltText())"/>
+            </a>
+        }
+        else
+        {
+            <img id="meme-preview" src="@(previewUrl)" alt="@(@Model.GetAltText())" title="@(@Model.GetAltText())"/>
+        }
     </div>
 </div>


### PR DESCRIPTION
Whenever I finish building a meme, for whatever reason, my mind wants to copy the meme URL from the browser address bar. And I _routinely_ copy and share the URL to the [builder](http://upboat.me/Builder/cpf/shared%20url%20to%20builder/instead%20of%20real%20url.jpg) page instead of the URL to the [actual meme](http://upboat.me/tmimitw/I-don't-always-copy-URLs/but-when-I-do,-I-copy-them-from-the-address-bar.jpg). (And I **know** I'm not the only one! :wink: )

Providing a clickable link to the meme image makes it easier to send the browser to the meme URL. The preview image seemed an obvious, though inconspicuous, choice.

Subtle, but (for me at least) very helpful.

Thoughts?
